### PR TITLE
Strip non names

### DIFF
--- a/R/gh_request.R
+++ b/R/gh_request.R
@@ -65,6 +65,7 @@ gh_set_endpoint <- function(x) {
 
   x$endpoint <- endpoint
   x$params <- x$params[!done]
+  x$params <- cleanse_names(x$params)
   x
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,7 +32,7 @@ has_no_names <- function(x) all(!has_name(x))
 
 ## if all names are "", strip completely
 cleanse_names <- function(x) {
-  if (all(has_no_names(x))) {
+  if (has_no_names(x)) {
     names(x) <- NULL
   }
   x

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,6 +30,14 @@ has_name <- function(x) {
 
 has_no_names <- function(x) all(!has_name(x))
 
+## if all names are "", strip completely
+cleanse_names <- function(x) {
+  if (all(has_no_names(x))) {
+    names(x) <- NULL
+  }
+  x
+}
+
 ## to process HTTP headers, i.e. combine defaults w/ user-specified headers
 ## in the spirit of modifyList(), except
 ## x and y are vectors (not lists)

--- a/tests/testthat/test-build_request.R
+++ b/tests/testthat/test-build_request.R
@@ -14,3 +14,14 @@ test_that("method arg sets default method", {
   r <- gh_build_request("/rate_limit", method = "POST")
   expect_equal(r$method, "POST")
 })
+
+test_that("parameter substitution is equivalent to direct specification", {
+  subst <-
+    gh_build_request("POST /repos/:org/:repo/issues/:number/labels",
+                     params = list(org = "ORG", repo = "REPO", number = "1",
+                                   "body"))
+  spec <-
+    gh_build_request("POST /repos/ORG/REPO/issues/1/labels",
+                     params = list("body"))
+  expect_identical(subst, spec)
+})


### PR DESCRIPTION
If all names are `""`, they need to be stripped, in order to produce the correct JSON body. Discovered when trying to set issue labels.