### PR TITLE
Add additional classes to returned error objects

### DIFF
--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -21,7 +21,7 @@ gh_process_response <- function(response) {
       headers = heads,
       message = paste0("GitHub API error (", status_code(response), "): ",
                        heads$`status`, "\n  ", res$message, "\n")
-    ), class = c("condition", "error"))
+    ), class = c("github_error", status_code(response), "condition", "error"))
     stop(cond)
   }
 

--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -21,7 +21,7 @@ gh_process_response <- function(response) {
       headers = heads,
       message = paste0("GitHub API error (", status_code(response), "): ",
                        heads$`status`, "\n  ", res$message, "\n")
-    ), class = c("github_error", status_code(response), "condition", "error"))
+    ), class = c("github_error", paste0("http_error_", status_code(response)), "error", "condition"))
     stop(cond)
   }
 

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -3,12 +3,12 @@ test_that("errors return a github_error object", {
   e <- tryCatch(gh("/missing"), error = identity)
 
   expect_s3_class(e, "github_error")
-  expect_s3_class(e, "404")
+  expect_s3_class(e, "http_error_404")
 })
 
 test_that("can catch a given status directly", {
-  e <- tryCatch(gh("/missing"), "404" = identity)
+  e <- tryCatch(gh("/missing"), "http_error_404" = identity)
 
   expect_s3_class(e, "github_error")
-  expect_s3_class(e, "404")
+  expect_s3_class(e, "http_error_404")
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -1,0 +1,14 @@
+context("github_error")
+test_that("errors return a github_error object", {
+  e <- tryCatch(gh("/missing"), error = identity)
+
+  expect_s3_class(e, "github_error")
+  expect_s3_class(e, "404")
+})
+
+test_that("can catch a given status directly", {
+  e <- tryCatch(gh("/missing"), "404" = identity)
+
+  expect_s3_class(e, "github_error")
+  expect_s3_class(e, "404")
+})


### PR DESCRIPTION
This allows you to catch a github_error or the exact status code
directly.